### PR TITLE
Revising placement of location text

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import logo from './logo.svg';
 import './App.css';
 import Weather from './Weather';
 
@@ -7,13 +6,6 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <h1 className="App-title">Welcome to React</h1>
-        </header>
-        <p className="App-intro">
-          To get started, edit <code>src/App.js</code> and save to reload.
-        </p>
         <Weather />
       </div>
     );

--- a/client/src/Weather.jsx
+++ b/client/src/Weather.jsx
@@ -39,9 +39,9 @@ class Weather extends Component {
         return(
             <section id="weather">
                 <h1>5-Day Forecast</h1>
+                <h2 id="location">{location.name}</h2>
                 {forecast.map( (el, i) =>
                     <section className="forecast" key={i}>
-                        <h2 id="location">{location.name}</h2>
                         <p id="day">Day:{" "}{new Date(el.date_epoch*1000).toUTCString().slice(0, 16)}</p>
                         <img src={el.day.condition.icon} alt={el.day.condition.text} />
                         <p id="high-temp">High:{" "}{el.day.maxtemp_f} &deg;F</p>


### PR DESCRIPTION
Previously, the location text was included in the mapping of the 5-day forecast. I moved the location text to above the mapping. this way, the name of the location only appears once rather than 5 times. 

I also deleted the default jsx in App.js that came with the create-react-app.